### PR TITLE
update(docs): restructure project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,289 +1,24 @@
 # web_api_knowledge
-This is a simple app is aimed to solidify and escalate web api knowledge.
 
-## Full Stack With Docker Compose
+## Summary
 
-The recommended local workflow is Docker Compose. It runs MariaDB, the FastAPI backend, and a production nginx frontend container from one command.
+`web_api_knowledge` is a full-stack learning project for Web API concepts using FastAPI, MariaDB, and React/Vite. The app includes authentication plus prompt CRUD flows backed by a SQLModel data model.
 
-### One-Command Startup
+## Quick Start
 
-Run this from the repository root:
+The startup script deploys the frontend, backend, and MariaDB with Docker Compose, waits for service readiness, and verifies basic connectivity.
 
 ```bash
 ./scripts/run-compose-stack.sh
 ```
 
-The script:
-
-- Detects `docker compose` and falls back to `docker-compose` if the plugin is unavailable
-- Runs `up --build -d` from the repository root
-- Waits for healthy `mariadb` and `backend` services
-- Checks the frontend at `http://127.0.0.1:8080/`
-- Checks the backend direct endpoint at `http://127.0.0.1:8000/`
-- Checks nginx API proxying through `http://127.0.0.1:8080/api/v1/auth/login`
-- Checks MariaDB connectivity with `mariadb-admin ping`
-- Publishes MariaDB on host port `3306` by default, or automatically uses the next available Docker port from `3307` to `3319` when `3306` is already used by another Docker container
-
-Use existing images without rebuilding:
-
-```bash
-./scripts/run-compose-stack.sh --no-build
-```
-
-Increase the readiness timeout when running the first database initialization on a slow machine:
-
-```bash
-./scripts/run-compose-stack.sh --timeout 180
-```
-
-### Manual Compose Startup
-
-If you prefer to run Compose manually, use:
-
-```bash
-docker compose up --build -d
-```
-
-If your Docker CLI does not have the Compose plugin, use the legacy command:
-
-```bash
-docker-compose up --build -d
-```
-
-The frontend serves the built React app and proxies same-origin `/api/*` requests to the backend service.
-
-URLs:
+Primary URLs:
 
 - Frontend: `http://127.0.0.1:8080`
-- Backend through frontend proxy: `http://127.0.0.1:8080/api/v1/...`
-- Backend direct developer port: `http://127.0.0.1:8000`
-- MariaDB direct developer port: `127.0.0.1:3306` by default
+- Backend direct: `http://127.0.0.1:8000`
+- API through frontend proxy: `http://127.0.0.1:8080/api/v1/...`
 
-Override the published MariaDB host port for local inspection when needed:
-
-```bash
-MARIADB_HOST_PORT=3307 docker compose up --build -d
-```
-
-Legacy fallback:
-
-```bash
-MARIADB_HOST_PORT=3307 docker-compose up --build -d
-```
-
-Stop the stack:
-
-```bash
-docker compose down
-```
-
-Reset the database volume too:
-
-```bash
-docker compose down -v
-```
-
-Check service health and logs:
-
-```bash
-docker compose ps
-docker compose logs backend
-docker compose logs frontend
-docker compose logs mariadb
-```
-
-Legacy fallback:
-
-```bash
-docker-compose ps
-docker-compose logs backend
-docker-compose logs frontend
-docker-compose logs mariadb
-```
-
-The backend receives `DB_URL=mariadb+mariadbconnector://webapi_user:webapi_password@mariadb:3306/crud_data` from Compose. Inside containers, service names such as `mariadb` and `backend` are used instead of `127.0.0.1`.
-
-## Verify The Docker Compose Stack
-
-After running `./scripts/run-compose-stack.sh` or manual Compose startup, use these commands for additional checks.
-
-Check the frontend and proxied API:
-
-```bash
-curl http://127.0.0.1:8080/
-curl -i -X POST http://127.0.0.1:8080/api/v1/auth/login -H "Content-Type: application/json" -d '{}'
-```
-
-The invalid login request should return HTTP `422`, which confirms nginx forwarded the API request to FastAPI.
-
-Check the backend direct developer port:
-
-```bash
-curl http://127.0.0.1:8000/
-```
-
-Create a user through the frontend proxy. Change `username`, `phone`, or `email` before rerunning because those fields must be unique:
-
-```bash
-curl -X POST http://127.0.0.1:8080/api/v1/auth/signup -H "Content-Type: application/json" -d '{"username":"demo_user_001","name":"Demo","last_name":"User","phone":"5550000001","email":"demo001@example.com","hashed_password":"demo-password"}'
-```
-
-Login and store the token without requiring `jq`:
-
-```bash
-TOKEN=$(curl -s -X POST http://127.0.0.1:8080/api/v1/auth/login -H "Content-Type: application/json" -d '{"username":"demo_user_001","password":"demo-password"}' | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
-```
-
-Create a prompt using the token. The `rate` field must be a string because the API schema defines it as text:
-
-```bash
-curl -X POST http://127.0.0.1:8080/api/v1/prompts -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"model_name":"gpt-demo","prompt_text":"Explain FastAPI in one sentence.","category":"demo","rate":"5"}'
-```
-
-Confirm the prompt is readable through the API:
-
-```bash
-curl http://127.0.0.1:8080/api/v1/prompts -H "Authorization: Bearer $TOKEN"
-```
-
-Open a MariaDB shell inside the database container:
-
-```bash
-docker compose exec mariadb mariadb -u webapi_user -pwebapi_password crud_data
-```
-
-Run these SQL commands:
-
-```sql
-SHOW TABLES;
-SELECT id, username, email FROM `user`;
-SELECT id, user_id, model_name, category, rate FROM prompts;
-```
-
-## Manual Backend With MariaDB
-
-Run these commands from the repository root.
-
-Build the backend image:
-
-```bash
-docker build -t webapi:dev .
-```
-
-Create a Docker network for the backend and database:
-
-```bash
-docker network create webapi-net || true
-```
-
-Start MariaDB in one copy-paste command:
-
-```bash
-docker run -d --name webapi-mariadb --network webapi-net -p 3306:3306 -e MARIADB_ROOT_PASSWORD=root_password -e MARIADB_DATABASE=crud_data -e MARIADB_USER=webapi_user -e MARIADB_PASSWORD=webapi_password -v webapi-mariadb-data:/var/lib/mysql mariadb:11
-```
-
-This starts a MariaDB container named `webapi-mariadb`, creates database `crud_data`, creates user `webapi_user` with password `webapi_password`, stores data in the `webapi-mariadb-data` volume, and exposes MariaDB on host port `3306` for local inspection.
-
-Wait until MariaDB is ready before starting the backend:
-
-```bash
-docker exec webapi-mariadb mariadb-admin ping -h 127.0.0.1 -u webapi_user -pwebapi_password
-```
-
-Start the backend with `DB_URL` pointed at the MariaDB container hostname:
-
-```bash
-docker run --rm --name webapi-backend --network webapi-net -p 8000:8000 -e DB_URL="mariadb+mariadbconnector://webapi_user:webapi_password@webapi-mariadb:3306/crud_data" webapi:dev
-```
-
-Inside the Docker network, the database host is `webapi-mariadb`, not `127.0.0.1`.
-
-### All-In-One Startup
-
-After building the image, this block starts the network, MariaDB, checks readiness, and runs the backend:
-
-```bash
-docker network create webapi-net || true
-docker run -d --name webapi-mariadb --network webapi-net -p 3306:3306 -e MARIADB_ROOT_PASSWORD=root_password -e MARIADB_DATABASE=crud_data -e MARIADB_USER=webapi_user -e MARIADB_PASSWORD=webapi_password -v webapi-mariadb-data:/var/lib/mysql mariadb:11
-docker exec webapi-mariadb mariadb-admin ping -h 127.0.0.1 -u webapi_user -pwebapi_password
-docker run --rm --name webapi-backend --network webapi-net -p 8000:8000 -e DB_URL="mariadb+mariadbconnector://webapi_user:webapi_password@webapi-mariadb:3306/crud_data" webapi:dev
-```
-
-## Verify The Manual API
-
-Keep the backend container running in one terminal, then run these commands from another terminal.
-
-Check the root endpoint:
-
-```bash
-curl http://127.0.0.1:8000/
-```
-
-Create a user. Change `username`, `phone`, or `email` before rerunning because those fields must be unique:
-
-```bash
-curl -X POST http://127.0.0.1:8000/api/v1/auth/signup -H "Content-Type: application/json" -d '{"username":"demo_user_001","name":"Demo","last_name":"User","phone":"5550000001","email":"demo001@example.com","hashed_password":"demo-password"}'
-```
-
-Login and store the token without requiring `jq`:
-
-```bash
-TOKEN=$(curl -s -X POST http://127.0.0.1:8000/api/v1/auth/login -H "Content-Type: application/json" -d '{"username":"demo_user_001","password":"demo-password"}' | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
-```
-
-Create a prompt using the token. The `rate` field must be a string because the API schema defines it as text:
-
-```bash
-curl -X POST http://127.0.0.1:8000/api/v1/prompts -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"model_name":"gpt-demo","prompt_text":"Explain FastAPI in one sentence.","category":"demo","rate":"5"}'
-```
-
-Confirm the prompt is readable through the API:
-
-```bash
-curl http://127.0.0.1:8000/api/v1/prompts -H "Authorization: Bearer $TOKEN"
-```
-
-## Verify Manual MariaDB Data
-
-Open a MariaDB shell inside the database container:
-
-```bash
-docker exec -it webapi-mariadb mariadb -u webapi_user -pwebapi_password crud_data
-```
-
-Run these SQL commands:
-
-```sql
-SHOW TABLES;
-SELECT id, username, email FROM `user`;
-SELECT id, user_id, model_name, category, rate FROM prompts;
-```
-
-## Standalone SQLite Smoke Test
-
-This quick command runs the backend without `DB_URL`, so the app falls back to SQLite inside the container:
-
-```bash
-docker build -t webapi:dev . && docker run --rm -p 8000:8000 webapi:dev
-```
-
-## Troubleshooting
-
-If Compose startup fails with `Bind for :::3306 failed: port is already allocated`, another container or local database is already using MariaDB's host port. The startup script automatically chooses a fallback MariaDB port when the conflict is another Docker container. For manual Compose startup, set `MARIADB_HOST_PORT=3307` or another free port.
-
-Check running Docker containers:
-
-```bash
-docker ps --format 'table {{.Names}}\t{{.Ports}}'
-```
-
-If the old manual backend workflow containers are running, remove them before starting Compose:
-
-```bash
-docker rm -f webapi-mariadb webapi-backend
-```
-
-If a previous Compose stack is running, stop it from the repository root:
+Stop the stack from the repository root:
 
 ```bash
 docker compose down
@@ -291,38 +26,17 @@ docker compose down
 
 Use `docker-compose down` if your environment only has the legacy Compose command.
 
-If port `8000` or `8080` is already allocated, stop the service using that port or edit `docker-compose.yml` to publish a different host port.
+## Documentation
 
-If the backend logs show SQLite, confirm the backend `docker run` command includes `-e DB_URL="mariadb+mariadbconnector://webapi_user:webapi_password@webapi-mariadb:3306/crud_data"`.
+- [`frontend/README.md`](frontend/README.md): frontend local development, production build, Docker, nginx proxying, and environment notes.
+- [`webapi/README.md`](webapi/README.md): backend deployment, MariaDB operations, API checks, configuration, and troubleshooting.
+- [`webapi/tests/README.md`](webapi/tests/README.md): backend test commands and CI/CD test mapping.
+- [`plans/dbdiagram.md`](plans/dbdiagram.md): database and ORM diagram details for dbdiagram.io.
 
-If the backend fails during startup, MariaDB may not be ready yet. Run the readiness check again, then restart the backend container.
+## Repository Layout
 
-If container names already exist, remove the old containers:
-
-```bash
-docker rm -f webapi-mariadb webapi-backend
-```
-
-To reset database data too, remove the named volume:
-
-```bash
-docker volume rm webapi-mariadb-data
-```
-
-## Database diagram documentation
-
-The ORM model and relational mapping documentation for dbdiagram.io is available at [`plans/dbdiagram.md`](plans/dbdiagram.md).
-
-## Frontend v1
-
-A minimal frontend scaffold is available in [`frontend/`](frontend/).
-
-Run it locally:
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-Detailed frontend docs are in [`frontend/README.md`](frontend/README.md).
+- `frontend/`: React, TypeScript, and Vite frontend served by nginx in Docker.
+- `webapi/`: FastAPI backend application, API routes, models, configuration, and database connections.
+- `webapi/tests/`: pytest suites for functional route tests and nonfunctional CI checks.
+- `scripts/`: local automation, including the full-stack Compose startup script.
+- `docker-compose.yml`: MariaDB, backend, and frontend service definitions for local full-stack runs.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,51 +1,64 @@
-# Frontend v1
+# Frontend
 
-Minimal React + TypeScript + Vite frontend for login and prompts CRUD.
+## Overview
+
+This is a React + TypeScript + Vite app for login and prompts CRUD. The API client defaults to the relative base URL `/api/v1`, which works with both the Vite dev proxy and the production nginx proxy.
 
 ## Requirements
 
-- Node.js 20.19+ recommended (project can build with warnings on Node 18 in this environment)
-- Backend API running at `http://127.0.0.1:8000`
+- Node.js 20.19+ recommended.
+- Backend API available at `http://127.0.0.1:8000` for local Vite development.
 
-## Run locally
+## Local Development
+
+Run these commands from `frontend/`:
 
 ```bash
 npm install
 npm run dev
 ```
 
-Vite proxies `/api/*` requests to `http://127.0.0.1:8000` via [`vite.config.ts`](vite.config.ts).
+Vite proxies `/api/*` requests to `http://127.0.0.1:8000` through [`vite.config.ts`](vite.config.ts). This proxy only applies to `npm run dev`.
 
-## Run With Docker
+## Manual Production Build
 
-From the repository root, run the full production-like stack:
+Run these commands from `frontend/`:
+
+```bash
+npm ci
+npm run build
+npm run preview
+```
+
+`npm run preview` serves the built static output for local inspection. It does not replace the production nginx proxy used by the full Docker stack.
+
+## Docker Deployment
+
+For the full production-like stack, run this from the repository root:
 
 ```bash
 ./scripts/run-compose-stack.sh
 ```
 
-The root startup script runs Docker Compose, waits for service readiness, and verifies frontend, backend, nginx API proxy, and MariaDB connectivity. Manual Compose startup also works with `docker compose up --build -d` or `docker-compose up --build -d`.
-
-The frontend image is built by [`Dockerfile`](Dockerfile). It installs dependencies with `npm ci`, runs `npm run build`, and serves the generated `dist/` files with nginx.
-
 Open the frontend at `http://127.0.0.1:8080`.
 
-In Docker mode, nginx uses [`nginx.conf`](nginx.conf) to:
+To build only the frontend image, run this from `frontend/`:
 
-- Serve the React SPA from `/usr/share/nginx/html`
-- Fallback unknown non-API routes to `index.html`
-- Proxy `/api/*` requests to the Compose backend service at `http://backend:8000`
+```bash
+docker build -t webapi-frontend:dev .
+```
 
-The browser still calls the relative default API base URL `/api/v1`. Do not set it to `http://backend:8000`; `backend` is only resolvable inside the Docker network, not from the browser.
+[`Dockerfile`](Dockerfile) uses a Node build stage and an nginx runtime stage. [`nginx.conf`](nginx.conf) serves the React SPA, falls back non-API routes to `index.html`, and proxies `/api/` to the Compose backend service at `http://backend:8000`.
 
-The Vite proxy in [`vite.config.ts`](vite.config.ts) is only used by local `npm run dev`. Production Docker serving uses nginx instead.
+The browser should keep using the relative API base URL `/api/v1`. Do not set a browser-facing API URL to `http://backend:8000`; `backend` is only resolvable inside the Docker network.
 
 ## Scripts
 
-- `npm run dev` start development server
-- `npm run build` typecheck and production build
-- `npm run lint` run ESLint
-- `npm run test` run Vitest tests
+- `npm run dev`: start the Vite development server.
+- `npm run build`: typecheck and create a production build.
+- `npm run lint`: run ESLint.
+- `npm run test`: run Vitest tests.
+- `npm run preview`: serve the built output locally.
 
 ## Environment
 
@@ -53,19 +66,19 @@ Optional:
 
 - `VITE_API_BASE_URL=/api/v1`
 
-Default base URL is already `/api/v1` in [`src/lib/http/api-client.ts`](src/lib/http/api-client.ts).
+The default base URL is already `/api/v1` in [`src/lib/http/api-client.ts`](src/lib/http/api-client.ts).
 
-## Architecture summary
+## Architecture Summary
 
-- Routing in [`src/app/router.tsx`](src/app/router.tsx)
-- Providers in [`src/app/providers.tsx`](src/app/providers.tsx)
-- In-memory auth session in [`src/features/auth/auth-store.tsx`](src/features/auth/auth-store.tsx)
-- Login + user id resolution in [`src/features/auth/auth-service.ts`](src/features/auth/auth-service.ts)
-- Prompts CRUD in [`src/features/prompts/prompts-service.ts`](src/features/prompts/prompts-service.ts)
-- Design tokens and themes in [`src/styles/tokens.css`](src/styles/tokens.css), [`src/styles/themes.css`](src/styles/themes.css), and [`src/styles/base.css`](src/styles/base.css)
+- Routing: [`src/app/router.tsx`](src/app/router.tsx)
+- Providers: [`src/app/providers.tsx`](src/app/providers.tsx)
+- In-memory auth session: [`src/features/auth/auth-store.tsx`](src/features/auth/auth-store.tsx)
+- Login and user id resolution: [`src/features/auth/auth-service.ts`](src/features/auth/auth-service.ts)
+- Prompts CRUD: [`src/features/prompts/prompts-service.ts`](src/features/prompts/prompts-service.ts)
+- Design tokens and themes: [`src/styles/tokens.css`](src/styles/tokens.css), [`src/styles/themes.css`](src/styles/themes.css), and [`src/styles/base.css`](src/styles/base.css)
 
-## UX behavior
+## UX Behavior
 
-- Session is memory-only; page reload requires login again
-- `user_id` is resolved after login by calling `/api/v1/users` and matching JWT username
-- Prompt list treats backend 404 (`No prompts found`) as empty state
+- Session is memory-only; page reload requires login again.
+- `user_id` is resolved after login by calling `/api/v1/users` and matching the JWT username.
+- The prompt list treats backend `404` responses for `No prompts found` as an empty state.

--- a/webapi/README.md
+++ b/webapi/README.md
@@ -1,0 +1,261 @@
+# WebAPI Backend
+
+## Overview
+
+The backend is a FastAPI app with users, auth, prompts, SQLModel persistence, MariaDB support, and a SQLite fallback. The ASGI app object is `myapp` in [`main.py`](main.py), and API routes are mounted under `/api/v1`.
+
+## Requirements
+
+- Python 3.12.
+- MariaDB client/build system packages when installing the backend dependencies locally.
+- Python dependencies from the root [`requirements.txt`](../requirements.txt).
+
+## Local Development Without Docker
+
+Use this flow when developing the FastAPI backend directly on your machine.
+
+Create and activate a virtual environment from the repository root:
+
+```bash
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Run the backend from `webapi/`:
+
+```bash
+cd webapi
+uvicorn main:myapp --reload --host 127.0.0.1 --port 8000
+```
+
+By default, the app uses SQLite because `DB_URL` is unset. This creates `webapi/crud_data.db`, which is convenient for local development.
+
+To use a local MariaDB server instead, create the database and user first, then export `DB_URL` before starting Uvicorn:
+
+```bash
+export DB_URL="mariadb+mariadbconnector://webapi_user:webapi_password@127.0.0.1:3306/crud_data"
+uvicorn main:myapp --reload --host 127.0.0.1 --port 8000
+```
+
+The local backend is available at `http://127.0.0.1:8000`, with API routes under `http://127.0.0.1:8000/api/v1`. Redis is only required for password recovery endpoints; most auth, users, and prompts development can run without starting Redis.
+
+## Run With Docker Compose
+
+The recommended workflow is the full-stack Compose script from the repository root:
+
+```bash
+./scripts/run-compose-stack.sh
+```
+
+Compose starts MariaDB, the FastAPI backend, and the nginx frontend. Inside the Compose network, the backend connects to the database host `mariadb`, and frontend nginx proxies API requests to the backend service name `backend`.
+
+Backend URLs:
+
+- Direct backend: `http://127.0.0.1:8000`
+- API through frontend proxy: `http://127.0.0.1:8080/api/v1/...`
+- MariaDB host port: `127.0.0.1:3306` by default
+
+Manual Compose startup from the repository root:
+
+```bash
+docker compose up --build -d
+docker compose ps
+docker compose logs backend
+```
+
+Use `docker-compose` instead of `docker compose` if your environment only has the legacy command.
+
+Override the published MariaDB host port for local inspection when needed:
+
+```bash
+MARIADB_HOST_PORT=3307 docker compose up --build -d
+```
+
+Stop or reset the Compose stack:
+
+```bash
+docker compose down
+docker compose down -v
+```
+
+`docker compose down -v` removes the database volume too.
+
+## Backend Docker Image
+
+Build the backend image from the repository root because the root [`Dockerfile`](../Dockerfile) copies both [`requirements.txt`](../requirements.txt) and `webapi/`:
+
+```bash
+docker build -t webapi:dev .
+```
+
+Run a standalone SQLite smoke test:
+
+```bash
+docker run --rm -p 8000:8000 webapi:dev
+```
+
+The backend uses `DB_URL` for MariaDB. If `DB_URL` is unset, it falls back to SQLite at `sqlite:///./crud_data.db`.
+
+## Manual MariaDB And Backend Docker Flow
+
+Use this advanced reference flow only when you need to run backend and MariaDB outside Compose.
+
+Build the backend image from the repository root:
+
+```bash
+docker build -t webapi:dev .
+```
+
+Create a Docker network for the backend and database:
+
+```bash
+docker network create webapi-net || true
+```
+
+Start MariaDB:
+
+```bash
+docker run -d --name webapi-mariadb --network webapi-net -p 3306:3306 -e MARIADB_ROOT_PASSWORD=root_password -e MARIADB_DATABASE=crud_data -e MARIADB_USER=webapi_user -e MARIADB_PASSWORD=webapi_password -v webapi-mariadb-data:/var/lib/mysql mariadb:11
+```
+
+Wait until MariaDB is ready:
+
+```bash
+docker exec webapi-mariadb mariadb-admin ping -h 127.0.0.1 -u webapi_user -pwebapi_password
+```
+
+Start the backend with `DB_URL` pointed at the MariaDB container hostname:
+
+```bash
+docker run --rm --name webapi-backend --network webapi-net -p 8000:8000 -e DB_URL="mariadb+mariadbconnector://webapi_user:webapi_password@webapi-mariadb:3306/crud_data" webapi:dev
+```
+
+Inside this Docker network, the database host is `webapi-mariadb`, not `127.0.0.1`.
+
+All-in-one manual startup after building the image:
+
+```bash
+docker network create webapi-net || true
+docker run -d --name webapi-mariadb --network webapi-net -p 3306:3306 -e MARIADB_ROOT_PASSWORD=root_password -e MARIADB_DATABASE=crud_data -e MARIADB_USER=webapi_user -e MARIADB_PASSWORD=webapi_password -v webapi-mariadb-data:/var/lib/mysql mariadb:11
+docker exec webapi-mariadb mariadb-admin ping -h 127.0.0.1 -u webapi_user -pwebapi_password
+docker run --rm --name webapi-backend --network webapi-net -p 8000:8000 -e DB_URL="mariadb+mariadbconnector://webapi_user:webapi_password@webapi-mariadb:3306/crud_data" webapi:dev
+```
+
+## API Verification
+
+Use `http://127.0.0.1:8080/api/v1` when the full Compose stack is running and you want to verify frontend nginx proxying. Use `http://127.0.0.1:8000/api/v1` when checking the backend port directly.
+
+Check the frontend proxy with an intentionally invalid login request:
+
+```bash
+curl -i -X POST http://127.0.0.1:8080/api/v1/auth/login -H "Content-Type: application/json" -d '{}'
+```
+
+HTTP `422` confirms nginx forwarded the request to FastAPI and FastAPI returned validation errors.
+
+Check the backend root endpoint directly:
+
+```bash
+curl http://127.0.0.1:8000/
+```
+
+Create a user through the frontend proxy. Change `username`, `phone`, or `email` before rerunning because those fields must be unique:
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/auth/signup -H "Content-Type: application/json" -d '{"username":"demo_user_001","name":"Demo","last_name":"User","phone":"5550000001","email":"demo001@example.com","hashed_password":"demo-password"}'
+```
+
+Login and store the token without requiring `jq`:
+
+```bash
+TOKEN=$(curl -s -X POST http://127.0.0.1:8080/api/v1/auth/login -H "Content-Type: application/json" -d '{"username":"demo_user_001","password":"demo-password"}' | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
+```
+
+Create a prompt using the token. The `rate` field must be a string because the API schema defines it as text:
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/v1/prompts -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"model_name":"gpt-demo","prompt_text":"Explain FastAPI in one sentence.","category":"demo","rate":"5"}'
+```
+
+Confirm prompts are readable through the API:
+
+```bash
+curl http://127.0.0.1:8080/api/v1/prompts -H "Authorization: Bearer $TOKEN"
+```
+
+For direct backend checks, replace `http://127.0.0.1:8080/api/v1` with `http://127.0.0.1:8000/api/v1` in the same API commands.
+
+## Database Access
+
+Open a MariaDB shell inside the Compose database service:
+
+```bash
+docker compose exec mariadb mariadb -u webapi_user -pwebapi_password crud_data
+```
+
+Use `docker-compose exec mariadb ...` if your environment only has the legacy Compose command.
+
+The startup script also prints a container lookup form for entering the Compose database container:
+
+```bash
+docker exec -ti $(docker ps -aqf "name=^/web_api_knowledge_mariadb*") mariadb -u webapi_user -pwebapi_password
+```
+
+If you are using the manual backend flow, use the named manual container instead:
+
+```bash
+docker exec -it webapi-mariadb mariadb -u webapi_user -pwebapi_password crud_data
+```
+
+Useful SQL checks:
+
+```sql
+SHOW TABLES;
+SELECT id, username, email FROM `user`;
+SELECT id, user_id, model_name, category, rate FROM prompts;
+```
+
+## Configuration
+
+- `DB_URL` controls the MariaDB connection. If unset, the backend defaults to SQLite at `sqlite:///./crud_data.db`.
+- JWT and mail settings are read in [`core/config.py`](core/config.py).
+- Redis is configured for `127.0.0.1:6379` in [`core/config.py`](core/config.py) and is only needed by password recovery endpoints.
+- The backend Docker image includes a deterministic `fastapi_mail/config.py` dependency patch after installing pinned requirements.
+
+## Troubleshooting
+
+If Compose startup fails with `Bind for :::3306 failed: port is already allocated`, another container or local database is already using MariaDB's host port. The startup script automatically chooses a fallback MariaDB port when the conflict is another Docker container. For manual Compose startup, set `MARIADB_HOST_PORT=3307` or another free port.
+
+Check running Docker containers:
+
+```bash
+docker ps --format 'table {{.Names}}\t{{.Ports}}'
+```
+
+If old manual backend workflow containers are running, remove them before starting Compose:
+
+```bash
+docker rm -f webapi-mariadb webapi-backend
+```
+
+If a previous Compose stack is running, stop it from the repository root:
+
+```bash
+docker compose down
+```
+
+Use `docker-compose down` if your environment only has the legacy Compose command.
+
+If port `8000` or `8080` is already allocated, stop the service using that port or edit `docker-compose.yml` to publish a different host port.
+
+If the backend logs show SQLite during the manual backend flow, confirm the backend `docker run` command includes `-e DB_URL="mariadb+mariadbconnector://webapi_user:webapi_password@webapi-mariadb:3306/crud_data"`.
+
+If the backend fails during manual startup, MariaDB may not be ready yet. Run the readiness check again, then restart the backend container.
+
+To reset manual database data too, remove the named volume:
+
+```bash
+docker volume rm webapi-mariadb-data
+```

--- a/webapi/tests/README.md
+++ b/webapi/tests/README.md
@@ -1,0 +1,65 @@
+# Backend Tests
+
+## Overview
+
+Backend tests use pytest and FastAPI `TestClient`. [`conftest.py`](conftest.py) overrides database and Redis dependencies with in-memory SQLite and fake Redis for most route tests.
+
+## Run From The Backend Directory
+
+Run backend test commands from `webapi/`:
+
+```bash
+cd webapi
+```
+
+## Main Test Commands
+
+Run the CI wrapper, which executes `tests/nonfunctional`:
+
+```bash
+pytest tests/test_ci.py -v
+```
+
+Run the CD/release wrapper, which executes `tests/functional`:
+
+```bash
+rm -f crud_data.db
+pytest tests/test_release.py -v
+```
+
+Run the functional suite directly:
+
+```bash
+pytest tests/functional -v
+```
+
+Run the nonfunctional suite directly:
+
+```bash
+pytest tests/nonfunctional -v
+```
+
+Run one targeted test:
+
+```bash
+pytest tests/functional/test_prompts_routes.py::test_create_prompt_user_not_found_returns_404 -v
+```
+
+## Local SQLite Data
+
+Some wrapper tests can create `webapi/crud_data.db` through the app's default SQLite fallback. Remove it before release-suite runs to match GitHub Actions' clean workspace behavior:
+
+```bash
+rm -f crud_data.db
+```
+
+## GitHub Actions Mapping
+
+- CI runs `pytest tests/test_ci.py -v` from `webapi/`.
+- CD runs `pytest tests/test_release.py -v` from `webapi/` after removing `crud_data.db`.
+
+## Tips
+
+- Keep route tests isolated through fixtures and dependency overrides.
+- Use targeted tests before full suites when debugging route behavior.
+- Fix dependency or import failures before investigating route assertions.


### PR DESCRIPTION
Split the overloaded root README into audience-specific docs for quick start, frontend development, backend operations, and backend tests. Preserve Docker Compose, MariaDB, API verification, and local backend development guidance in the relevant README files.