### PR TITLE
feat(prompts): add titled prompts with localized signup seeds

### DIFF
--- a/frontend/src/components/prompts/prompt-detail-dialog.tsx
+++ b/frontend/src/components/prompts/prompt-detail-dialog.tsx
@@ -38,9 +38,13 @@ export function PromptDetailDialog({
                 aria-labelledby="prompt-detail-title"
                 onMouseDown={(event) => event.stopPropagation()}
             >
-                <h2 id="prompt-detail-title">{t('prompts.detail.title')}</h2>
+                <h2 id="prompt-detail-title">{prompt.title}</h2>
                 <div className="prompt-detail-body">
                     <div className="prompt-detail-meta prompt-detail-summary">
+                        <div className="prompt-detail-field">
+                            <span className="label">{t('prompts.detail.titleLabel')}</span>
+                            <strong>{prompt.title}</strong>
+                        </div>
                         <div className="prompt-detail-field">
                             <span className="label">{t('prompts.detail.model')}</span>
                             <strong>{prompt.model_name}</strong>

--- a/frontend/src/components/prompts/prompt-form.tsx
+++ b/frontend/src/components/prompts/prompt-form.tsx
@@ -5,6 +5,7 @@ import type { PromptInput, PromptRecord } from '../../features/prompts/prompts-t
 import { promptSchema } from '../../lib/validation/prompt-schemas'
 import { Button } from '../ui/button'
 import { ComboboxInput } from '../ui/combobox-input'
+import { Input } from '../ui/input'
 import { RatingInput } from '../ui/rating-input'
 import { Select } from '../ui/select'
 import { Textarea } from '../ui/textarea'
@@ -32,6 +33,7 @@ export function PromptForm({
 }: PromptFormProps) {
     const { t } = useTranslation()
     const [form, setForm] = useState<PromptInput>({
+        title: initialValue?.title ?? '',
         model_name: initialValue?.model_name ?? '',
         prompt_text: initialValue?.prompt_text ?? '',
         category: initialValue?.category ?? '',
@@ -74,12 +76,20 @@ export function PromptForm({
         setFieldErrors({})
         await onSubmit(parsed.data)
         if (!isEdit) {
-            setForm({ model_name: '', prompt_text: '', category: '', rate: 3 })
+            setForm({ title: '', model_name: '', prompt_text: '', category: '', rate: 3 })
         }
     }
 
     return (
         <form className="prompt-form" onSubmit={handleSubmit}>
+            <Input
+                label={t('prompts.form.title')}
+                value={form.title}
+                onChange={(e) => handleChange('title', e.target.value)}
+                error={fieldErrors.title}
+                placeholder={t('prompts.form.titlePlaceholder')}
+                maxLength={120}
+            />
             <ComboboxInput
                 label={t('prompts.form.model')}
                 options={modelOptions}

--- a/frontend/src/components/prompts/prompt-list.tsx
+++ b/frontend/src/components/prompts/prompt-list.tsx
@@ -47,10 +47,11 @@ export function PromptList({ prompts, onEdit, onDelete }: PromptListProps) {
                             onClick={() => setSelectedPrompt(prompt)}
                         >
                             <span className="prompt-list-content">
-                                <strong>{prompt.model_name}</strong>
+                                <strong>{prompt.title}</strong>
                                 <span className="prompt-list-summary">{summary}</span>
                             </span>
                             <span className="prompt-list-meta">
+                                <span className="badge">{prompt.model_name}</span>
                                 <span className="badge">{prompt.category}</span>
                                 <span className="muted">{t('common.rating', { value: prompt.rate })}</span>
                             </span>

--- a/frontend/src/features/auth/auth-service.ts
+++ b/frontend/src/features/auth/auth-service.ts
@@ -17,6 +17,7 @@ export type SessionResolved = {
     username: string
     userId: number
     role: UserRole
+    preferredLanguage: UserRecord['preferred_language']
 }
 
 export async function loginAndResolveUserId(
@@ -34,6 +35,7 @@ export async function loginAndResolveUserId(
         username: currentUser.username,
         userId: currentUser.id,
         role: currentUser.role,
+        preferredLanguage: currentUser.preferred_language,
     }
 }
 
@@ -42,6 +44,20 @@ export function signup(input: RegisterInput): Promise<SignupResponse> {
         method: 'POST',
         body: JSON.stringify(input),
     })
+}
+
+export async function signupAndResolveSession(
+    input: RegisterInput,
+): Promise<SessionResolved> {
+    const response = await signup(input)
+
+    return {
+        token: response.access_token,
+        username: response.user.username,
+        userId: response.user.id,
+        role: response.user.role,
+        preferredLanguage: response.user.preferred_language,
+    }
 }
 
 export function getCurrentUser(token: string): Promise<UserRecord> {

--- a/frontend/src/features/auth/auth-store.tsx
+++ b/frontend/src/features/auth/auth-store.tsx
@@ -8,14 +8,15 @@ import {
     useState,
     type ReactNode,
 } from 'react'
-import { getCurrentUser, loginAndResolveUserId } from './auth-service'
-import type { UserRole } from './auth-types'
+import { getCurrentUser, loginAndResolveUserId, signupAndResolveSession } from './auth-service'
+import type { PreferredLanguage, RegisterInput, UserRole } from './auth-types'
 
 type SessionState = {
     token: string | null
     username: string | null
     userId: number | null
     role: UserRole | null
+    preferredLanguage: PreferredLanguage | null
 }
 
 type AuthContextValue = {
@@ -23,6 +24,7 @@ type AuthContextValue = {
     isAuthenticated: boolean
     isReady: boolean
     login: (username: string, password: string) => Promise<void>
+    signup: (input: RegisterInput) => Promise<void>
     logout: () => void
 }
 
@@ -42,6 +44,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         username: null,
         userId: null,
         role: null,
+        preferredLanguage: null,
     })
     const [isReady, setIsReady] = useState(() => !initialToken)
 
@@ -57,6 +60,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
                     username: user.username,
                     userId: user.id,
                     role: user.role,
+                    preferredLanguage: user.preferred_language,
                 })
             })
             .catch(() => {
@@ -79,12 +83,25 @@ export function AuthProvider({ children }: AuthProviderProps) {
             username: resolved.username,
             userId: resolved.userId,
             role: resolved.role,
+            preferredLanguage: resolved.preferredLanguage,
+        })
+    }, [])
+
+    const signup = useCallback(async (input: RegisterInput) => {
+        const resolved = await signupAndResolveSession(input)
+        sessionStorage.setItem(SESSION_TOKEN_KEY, resolved.token)
+        setSession({
+            token: resolved.token,
+            username: resolved.username,
+            userId: resolved.userId,
+            role: resolved.role,
+            preferredLanguage: resolved.preferredLanguage,
         })
     }, [])
 
     const logout = useCallback(() => {
         sessionStorage.removeItem(SESSION_TOKEN_KEY)
-        setSession({ token: null, username: null, userId: null, role: null })
+        setSession({ token: null, username: null, userId: null, role: null, preferredLanguage: null })
     }, [])
 
     const value = useMemo<AuthContextValue>(
@@ -93,9 +110,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
             isAuthenticated: Boolean(session.token),
             isReady,
             login,
+            signup,
             logout,
         }),
-        [isReady, login, logout, session],
+        [isReady, login, logout, session, signup],
     )
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/features/auth/auth-types.ts
+++ b/frontend/src/features/auth/auth-types.ts
@@ -8,12 +8,15 @@ export type LoginResponse = {
     token_type: string
 }
 
+export type PreferredLanguage = 'es' | 'en'
+
 export type RegisterInput = {
     username: string
     password: string
     name: string
     last_name: string
     email: string
+    preferred_language: PreferredLanguage
 }
 
 export type UserRole = 'user' | 'admin' | 'god'
@@ -24,11 +27,15 @@ export type UserRecord = {
     name: string
     last_name: string
     email: string
+    preferred_language: PreferredLanguage
     role: UserRole
 }
 
 export type SignupResponse = {
     message: string
+    access_token: string
+    token_type: string
+    user: UserRecord
 }
 
 export type RecoveryGenerateInput = {

--- a/frontend/src/features/prompts/prompts-types.ts
+++ b/frontend/src/features/prompts/prompts-types.ts
@@ -1,6 +1,7 @@
 export type PromptRecord = {
     id: number
     user_id: number
+    title: string
     model_name: string
     prompt_text: string
     category: string
@@ -8,6 +9,7 @@ export type PromptRecord = {
 }
 
 export type PromptInput = {
+    title: string
     model_name: string
     prompt_text: string
     category: string

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1,6 +1,6 @@
 export const en = {
     app: {
-        name: 'Prompt Catalog',
+        name: 'iPrompt',
         tagline: 'Personal library for prompts that work',
     },
     language: {
@@ -40,6 +40,39 @@ export const en = {
         previewEyebrow: 'Catalog preview',
         previewTitle: 'A warmer home for your reusable AI work',
         previewCopy: 'Preview how saved prompts can be organized with ratings, models, categories, and quick context before you commit them to your own library.',
+        creatorOffers: {
+            eyebrow: 'Free creator starter pack',
+            title: '3 creator-built prompts included with your free account.',
+            copy: 'Sign up and iPrompt seeds your catalog with three complete, editable prompts in your preferred language.',
+            included: 'Create a free account to unlock the full prompt bodies in your private catalog.',
+            cta: 'Create free account',
+            cards: [
+                {
+                    title: 'Appliance Value Expert',
+                    category: 'Finance & Investing',
+                    model: 'GPT',
+                    rating: '5/5',
+                    outcome: 'Compare appliance options in Mexico by price, warranty, ownership cost, reliability, and practical performance.',
+                    locked: 'Full quote workflow unlocks after signup.',
+                },
+                {
+                    title: 'Personal Meal Planning Expert',
+                    category: 'Personal Development',
+                    model: 'GPT',
+                    rating: '5/5',
+                    outcome: 'Plan realistic 30-day meals around budget, preferences, prep time, and safety-aware wellness context.',
+                    locked: 'Educational meal-planning prompt included after signup; not a replacement for clinical care.',
+                },
+                {
+                    title: 'Influencer Content Planner',
+                    category: 'Marketing & Sales',
+                    model: 'GPT',
+                    rating: '5/5',
+                    outcome: 'Build an editorial calendar with hooks, scripts, captions, repurposing ideas, and weekly metrics.',
+                    locked: 'Full two-step planning prompt unlocks in your catalog.',
+                },
+            ],
+        },
         benefitsLabel: 'Prompt library benefits',
         benefits: [
             {
@@ -103,6 +136,8 @@ export const en = {
         firstName: 'First name',
         lastName: 'Last name',
         email: 'Email',
+        preferredLanguage: 'Prompt language',
+        preferredLanguageHelp: 'Your starter prompts will be saved in this language. You can still switch the interface separately.',
         creating: 'Creating...',
         alreadyHaveAccount: 'Already have an account?',
         invalidCredentials: 'Invalid credentials',
@@ -153,6 +188,7 @@ export const en = {
             emptyRating: 'No ratings yet',
         },
         form: {
+            title: 'Title',
             model: 'Model',
             prompt: 'Prompt text',
             category: 'Category',
@@ -161,10 +197,12 @@ export const en = {
             update: 'Update prompt',
             knownModel: 'Select a known model from the list.',
             invalid: 'Invalid form data',
+            titlePlaceholder: 'Name this prompt so it is easy to find later.',
             promptPlaceholder: 'Paste the prompt that worked, including any constraints or context you want to reuse.',
         },
         detail: {
             title: 'Prompt details',
+            titleLabel: 'Title',
             model: 'Model',
             prompt: 'Prompt',
             category: 'Category',
@@ -190,7 +228,7 @@ export const en = {
         },
         editTitle: 'Edit prompt as god',
         allPrompts: 'All prompts',
-        promptMeta: 'User {{userId}} · {{category}} · Rating {{rating}}/5',
+        promptMeta: 'User {{userId}} · {{model}} · {{category}} · Rating {{rating}}/5',
         noPrompts: 'No prompts found.',
         deleteTitle: 'Delete this prompt?',
         deleteDescription: 'This removes the selected prompt from the catalog for every admin view.',

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -1,6 +1,6 @@
 export const es = {
     app: {
-        name: 'Catálogo de Prompts',
+        name: 'iPrompt',
         tagline: 'Biblioteca personal para prompts que funcionan',
     },
     language: {
@@ -40,6 +40,39 @@ export const es = {
         previewEyebrow: 'Vista previa del catálogo',
         previewTitle: 'Un espacio más claro para tu trabajo reutilizable con IA',
         previewCopy: 'Mira cómo tus prompts guardados pueden organizarse con calificaciones, modelos, categorías y contexto útil antes de llevarlos a tu propia biblioteca.',
+        creatorOffers: {
+            eyebrow: 'Pack inicial gratis para creadores',
+            title: '3 prompts creados para creadores incluidos con tu cuenta gratis.',
+            copy: 'Regístrate e iPrompt agrega a tu catálogo tres prompts completos y editables en tu idioma preferido.',
+            included: 'Crea una cuenta gratis para desbloquear los prompts completos en tu catálogo privado.',
+            cta: 'Crear cuenta gratis',
+            cards: [
+                {
+                    title: 'Experto cotizador de electrodomesticos',
+                    category: 'Finanzas e inversión',
+                    model: 'GPT',
+                    rating: '5/5',
+                    outcome: 'Compara opciones de electrodomésticos en México por precio, garantía, costo de propiedad, confiabilidad y desempeño práctico.',
+                    locked: 'El flujo completo de cotización se desbloquea después del registro.',
+                },
+                {
+                    title: 'Experto nutriologo personal',
+                    category: 'Desarrollo personal',
+                    model: 'GPT',
+                    rating: '5/5',
+                    outcome: 'Planea comidas realistas por 30 días con presupuesto, preferencias, tiempo de preparación y contexto de bienestar con enfoque seguro.',
+                    locked: 'Prompt educativo de planeación incluido después del registro; no reemplaza atención clínica.',
+                },
+                {
+                    title: 'Planeador para influencer',
+                    category: 'Marketing y ventas',
+                    model: 'GPT',
+                    rating: '5/5',
+                    outcome: 'Crea calendario editorial con hooks, guiones, captions, ideas de reutilización y métricas semanales.',
+                    locked: 'El prompt completo de planeación en dos pasos se desbloquea en tu catálogo.',
+                },
+            ],
+        },
         benefitsLabel: 'Beneficios de la biblioteca de prompts',
         benefits: [
             {
@@ -103,6 +136,8 @@ export const es = {
         firstName: 'Nombre',
         lastName: 'Apellido',
         email: 'Correo electrónico',
+        preferredLanguage: 'Idioma de prompts',
+        preferredLanguageHelp: 'Tus prompts iniciales se guardarán en este idioma. La interfaz se puede cambiar por separado.',
         creating: 'Creando...',
         alreadyHaveAccount: '¿Ya tienes una cuenta?',
         invalidCredentials: 'Credenciales inválidas',
@@ -153,6 +188,7 @@ export const es = {
             emptyRating: 'Sin calificaciones aún',
         },
         form: {
+            title: 'Título',
             model: 'Modelo',
             prompt: 'Texto del prompt',
             category: 'Categoría',
@@ -161,10 +197,12 @@ export const es = {
             update: 'Actualizar prompt',
             knownModel: 'Selecciona un modelo conocido de la lista.',
             invalid: 'Datos del formulario inválidos',
+            titlePlaceholder: 'Nombra este prompt para encontrarlo fácil después.',
             promptPlaceholder: 'Pega el prompt que funcionó, incluyendo restricciones o contexto que quieras reutilizar.',
         },
         detail: {
             title: 'Detalles del prompt',
+            titleLabel: 'Título',
             model: 'Modelo',
             prompt: 'Prompt',
             category: 'Categoría',
@@ -190,7 +228,7 @@ export const es = {
         },
         editTitle: 'Editar prompt como god',
         allPrompts: 'Todos los prompts',
-        promptMeta: 'Usuario {{userId}} · {{category}} · Calificación {{rating}}/5',
+        promptMeta: 'Usuario {{userId}} · {{model}} · {{category}} · Calificación {{rating}}/5',
         noPrompts: 'No se encontraron prompts.',
         deleteTitle: '¿Eliminar este prompt?',
         deleteDescription: 'Esto elimina el prompt seleccionado del catálogo para toda vista de administración.',

--- a/frontend/src/lib/validation/auth-schemas.ts
+++ b/frontend/src/lib/validation/auth-schemas.ts
@@ -11,6 +11,7 @@ export const registerSchema = z.object({
     email: z.string().email('Enter a valid email'),
     username: z.string().min(3, 'Username must be at least 3 characters'),
     password: z.string().min(6, 'Password must be at least 6 characters'),
+    preferred_language: z.enum(['es', 'en']),
 })
 
 export const recoveryRequestSchema = z.object({

--- a/frontend/src/lib/validation/prompt-schemas.ts
+++ b/frontend/src/lib/validation/prompt-schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 const PROMPT_TEXT_MAX_CHARS = 1_000_000
 
 export const promptSchema = z.object({
+    title: z.string().trim().min(1, 'Title is required').max(120, 'Title must be at most 120 characters'),
     model_name: z.string().trim().min(1, 'Model name is required'),
     prompt_text: z
         .string()

--- a/frontend/src/pages/admin/admin-prompts-page.tsx
+++ b/frontend/src/pages/admin/admin-prompts-page.tsx
@@ -225,10 +225,10 @@ export function AdminPromptsPage() {
                     {(promptsQuery.data ?? []).map((prompt) => (
                         <article key={prompt.id} className="list-item">
                             <div>
-                                <h3>{prompt.model_name}</h3>
+                                <h3>{prompt.title}</h3>
                                 <p>{prompt.prompt_text}</p>
                                 <p className="muted">
-                                    {t('admin.promptMeta', { userId: prompt.user_id, category: prompt.category, rating: prompt.rate })}
+                                    {t('admin.promptMeta', { userId: prompt.user_id, model: prompt.model_name, category: prompt.category, rating: prompt.rate })}
                                 </p>
                             </div>
                             {isGod ? (

--- a/frontend/src/pages/landing/landing-page.tsx
+++ b/frontend/src/pages/landing/landing-page.tsx
@@ -10,6 +10,14 @@ export function LandingPage() {
     const { t } = useTranslation()
     const benefits = t('landing.benefits', { returnObjects: true }) as Array<{ title: string; copy: string }>
     const workflow = t('landing.workflow', { returnObjects: true }) as string[]
+    const creatorOffers = t('landing.creatorOffers.cards', { returnObjects: true }) as Array<{
+        title: string
+        category: string
+        model: string
+        rating: string
+        outcome: string
+        locked: string
+    }>
 
     return (
         <main className="marketing-page">
@@ -75,6 +83,36 @@ export function LandingPage() {
                             </div>
                         </Card>
                     ))}
+                </div>
+            </section>
+
+            <section className="preview-section creator-offer-section" aria-labelledby="creator-offer-title">
+                <div className="section-heading preview-heading">
+                    <div>
+                        <p className="eyebrow">{t('landing.creatorOffers.eyebrow')}</p>
+                        <h2 id="creator-offer-title">{t('landing.creatorOffers.title')}</h2>
+                    </div>
+                    <p className="muted preview-copy">{t('landing.creatorOffers.copy')}</p>
+                </div>
+                <div className="sample-grid">
+                    {creatorOffers.map((offer) => (
+                        <Card key={offer.title} className="sample-card creator-offer-card">
+                            <div className="section-heading">
+                                <Badge tone="accent">{offer.model}</Badge>
+                                <span className="badge">{offer.rating}</span>
+                            </div>
+                            <div className="stack gap-tight">
+                                <p className="sample-category">{offer.category}</p>
+                                <h3>{offer.title}</h3>
+                                <p>{offer.outcome}</p>
+                                <p className="muted">{offer.locked}</p>
+                            </div>
+                        </Card>
+                    ))}
+                </div>
+                <div className="creator-offer-cta">
+                    <p className="muted">{t('landing.creatorOffers.included')}</p>
+                    <Link to="/register" className="button-link">{t('landing.creatorOffers.cta')}</Link>
                 </div>
             </section>
 

--- a/frontend/src/pages/register/register-page.tsx
+++ b/frontend/src/pages/register/register-page.tsx
@@ -6,17 +6,30 @@ import { Card } from '../../components/ui/card'
 import { LanguageSwitcher } from '../../components/i18n/language-switcher'
 import { InlineError } from '../../components/ui/inline-error'
 import { Input } from '../../components/ui/input'
+import { Select } from '../../components/ui/select'
 import { ThemeToggle } from '../../components/ui/theme-toggle'
-import { signup } from '../../features/auth/auth-service'
+import { useAuth } from '../../features/auth/auth-store'
 import { ApiError } from '../../lib/http/api-error'
 import { registerSchema } from '../../lib/validation/auth-schemas'
 
 export function RegisterPage() {
-    const { t } = useTranslation()
+    const { t, i18n } = useTranslation()
     const navigate = useNavigate()
-    const [form, setForm] = useState({ name: '', last_name: '', email: '', username: '', password: '' })
+    const { signup } = useAuth()
+    const [form, setForm] = useState({
+        name: '',
+        last_name: '',
+        email: '',
+        username: '',
+        password: '',
+        preferred_language: i18n.resolvedLanguage === 'en' ? 'en' : 'es',
+    })
     const [error, setError] = useState<string | null>(null)
     const [loading, setLoading] = useState(false)
+    const languageOptions = [
+        { value: 'es', label: t('language.spanish') },
+        { value: 'en', label: t('language.english') },
+    ]
 
     const updateField = (field: keyof typeof form, value: string) => {
         setForm((current) => ({ ...current, [field]: value }))
@@ -34,7 +47,7 @@ export function RegisterPage() {
             setLoading(true)
             setError(null)
             await signup(parsed.data)
-            navigate('/login?registered=1', { replace: true })
+            navigate('/app/prompts', { replace: true })
         } catch (err) {
             const message = err instanceof Error ? err.message : t('auth.unableToCreate')
             setError(err instanceof ApiError && err.status === 400 ? t('auth.usernameTaken') : message)
@@ -67,6 +80,13 @@ export function RegisterPage() {
                         <Input label={t('auth.email')} value={form.email} onChange={(event) => updateField('email', event.target.value)} autoComplete="email" />
                         <Input label={t('auth.username')} value={form.username} onChange={(event) => updateField('username', event.target.value)} autoComplete="username" />
                         <Input label={t('auth.password')} type="password" value={form.password} onChange={(event) => updateField('password', event.target.value)} autoComplete="new-password" />
+                        <Select
+                            label={t('auth.preferredLanguage')}
+                            options={languageOptions}
+                            value={form.preferred_language}
+                            onChange={(event) => updateField('preferred_language', event.target.value)}
+                        />
+                        <p className="muted form-helper">{t('auth.preferredLanguageHelp')}</p>
                         {error ? <InlineError message={error} /> : null}
                         <Button type="submit" disabled={loading}>{loading ? t('auth.creating') : t('nav.createAccount')}</Button>
                         <Link className="text-link" to="/login">{t('auth.alreadyHaveAccount')}</Link>

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -396,6 +396,10 @@ textarea:focus-visible {
     font-size: var(--font-sm);
 }
 
+.form-helper {
+    margin-top: calc(var(--space-2) * -1);
+}
+
 .list {
     display: grid;
     gap: var(--space-3);
@@ -483,11 +487,17 @@ textarea:focus-visible {
 
 .prompt-detail-dialog {
     width: min(720px, 100%);
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    min-height: 0;
 }
 
 .prompt-detail-body {
     display: grid;
     gap: var(--space-4);
+    min-height: 0;
+    overflow: auto;
+    padding-right: var(--space-1);
+    scrollbar-gutter: stable;
 }
 
 .prompt-detail-field {
@@ -496,12 +506,11 @@ textarea:focus-visible {
 }
 
 .prompt-detail-text {
-    max-height: min(46vh, 28rem);
-    overflow: auto;
     padding: var(--space-4);
     border: 1px solid var(--border);
     border-radius: var(--radius-md);
     background: var(--surface-soft);
+    overflow-wrap: anywhere;
     white-space: pre-wrap;
 }
 
@@ -608,6 +617,9 @@ textarea:focus-visible {
 
 .dialog-panel {
     width: min(440px, 100%);
+    max-width: calc(100vw - 2rem);
+    max-height: calc(100vh - 2rem);
+    max-height: calc(100dvh - 2rem);
     display: grid;
     gap: var(--space-4);
     border: 1px solid var(--border);
@@ -615,6 +627,7 @@ textarea:focus-visible {
     padding: var(--space-6);
     background: var(--surface);
     box-shadow: var(--shadow);
+    overflow: hidden;
 }
 
 .dialog-actions {
@@ -832,6 +845,28 @@ textarea:focus-visible {
     --sample-accent: #4f88c6;
 }
 
+.creator-offer-section {
+    --sample-accent: var(--accent-strong);
+}
+
+.creator-offer-section .sample-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.creator-offer-card {
+    min-height: 18rem;
+}
+
+.creator-offer-cta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    margin-top: var(--space-6);
+    padding-top: var(--space-5);
+    border-top: 1px solid var(--border);
+}
+
 .sample-category {
     color: var(--sample-accent, var(--accent));
     font-size: var(--font-sm);
@@ -941,6 +976,10 @@ textarea:focus-visible {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
+    .creator-offer-section .sample-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
     .workflow-strip {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -977,6 +1016,7 @@ textarea:focus-visible {
     .hero-grid,
     .feature-grid,
     .sample-grid,
+    .creator-offer-section .sample-grid,
     .workflow-strip,
     .stats-grid {
         grid-template-columns: 1fr;
@@ -989,6 +1029,7 @@ textarea:focus-visible {
 
     .marketing-nav,
     .auth-public-bar,
+    .creator-offer-cta,
     .final-cta {
         align-items: flex-start;
         flex-direction: column;
@@ -1009,8 +1050,6 @@ textarea:focus-visible {
     }
 
     .dialog-panel {
-        max-height: calc(100vh - 2rem);
-        overflow: auto;
         padding: var(--space-4);
     }
 

--- a/webapi/api/endpoints/v1/auths.py
+++ b/webapi/api/endpoints/v1/auths.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter, HTTPException, Depends, Body, Query
 from sqlmodel import Session, select
 from models.user import User
+from models.prompts import Prompts
 from passlib.hash import sha256_crypt
 from db.db_connection import get_session
 from auth.auth_service import authenticate_user, crear_jwt, get_current_user, get_current_db_user
+from core.creator_prompts import get_creator_prompt_seeds
 from infrastructure.email.smtp_service import send_email
 import secrets
 import base64
@@ -41,11 +43,43 @@ def signup(payload: UserCreate, session: Session = Depends(get_session)):
         last_name=payload.last_name,
         email=payload.email,
         hashed_password=sha256_crypt.hash(payload.password),
+        preferred_language=payload.preferred_language,
         role="user",
     )
     session.add(user)
+    session.flush()
+
+    for seed in get_creator_prompt_seeds(user.preferred_language):
+        session.add(
+            Prompts(
+                user_id=user.id,
+                title=seed["title"],
+                model_name=seed["model_name"],
+                prompt_text=seed["prompt_text"],
+                category=seed["category"],
+                rate=seed["rate"],
+            )
+        )
+
     session.commit()
-    return {"message": "User created successfully"}
+    session.refresh(user)
+    access_token = crear_jwt(
+        data={"sub": user.username, "user_id": user.id, "role": user.role}
+    )
+    return {
+        "message": "User created successfully",
+        "access_token": access_token,
+        "token_type": "bearer",
+        "user": {
+            "id": user.id,
+            "username": user.username,
+            "name": user.name,
+            "last_name": user.last_name,
+            "email": user.email,
+            "preferred_language": user.preferred_language,
+            "role": user.role,
+        },
+    }
 
 @router.post("/login")
 def login(request: LoginRequest, session: Session = Depends(get_session)):

--- a/webapi/api/endpoints/v1/prompts.py
+++ b/webapi/api/endpoints/v1/prompts.py
@@ -26,6 +26,7 @@ async def create_prompt(
 
     created_prompt = Prompts(
         user_id=prompt_user.id,
+        title=prompt.title,
         model_name=prompt.model_name,
         prompt_text=prompt.prompt_text,
         category=prompt.category,
@@ -102,6 +103,7 @@ def update_prompt(prompt_id: int, prompt: PromptCreate,
         raise HTTPException(status_code=404, detail="User not found for this prompt")
     if target_user_id != existing_prompt.user_id and current_user.role != "god":
         raise HTTPException(status_code=403, detail="Cannot reassign this prompt")
+    existing_prompt.title = prompt.title
     existing_prompt.model_name = prompt.model_name
     existing_prompt.prompt_text = prompt.prompt_text
     existing_prompt.category = prompt.category

--- a/webapi/core/creator_prompts.py
+++ b/webapi/core/creator_prompts.py
@@ -1,0 +1,249 @@
+from typing import Literal, TypedDict
+
+
+SupportedLanguage = Literal["es", "en"]
+
+
+class CreatorPromptSeed(TypedDict):
+    key: str
+    title: str
+    category: str
+    model_name: str
+    rate: int
+    prompt_text: str
+
+
+_SEED_METADATA = {
+    "appliance_quote_expert": {
+        "category": "finance",
+        "model_name": "gpt",
+        "rate": 5,
+    },
+    "personal_nutrition_expert": {
+        "category": "personal_development",
+        "model_name": "gpt",
+        "rate": 5,
+    },
+    "influencer_planner": {
+        "category": "marketing_sales",
+        "model_name": "gpt",
+        "rate": 5,
+    },
+}
+
+
+_LOCALIZED_SEEDS = {
+    "es": {
+        "appliance_quote_expert": {
+            "title": "Experto cotizador de electrodomesticos",
+            "prompt_text": """Actua como un experto cotizador de electrodomesticos para compradores en Mexico.
+
+Objetivo: ayudarme a comparar opciones de compra de forma practica, considerando precio, garantia, costo total de propiedad, confiabilidad y desempeno real para el uso que necesito.
+
+Primero pideme estos datos si no los proporciono:
+1. Tipo de electrodomestico y capacidad o tamano deseado.
+2. Presupuesto maximo y ciudad o tienda donde pienso comprar.
+3. Uso esperado: frecuencia, numero de personas y restricciones de espacio.
+4. Marcas o modelos que ya estoy considerando.
+5. Prioridades personales: precio, durabilidad, ahorro electrico, garantia, ruido, facilidad de reparacion o funciones inteligentes.
+
+Cuando tengas la informacion, evalua cada opcion con estos criterios y pesos:
+- Precio inicial: 20%.
+- Garantia, disponibilidad de refacciones y servicio tecnico: 20%.
+- Consumo electrico o costo operativo estimado: 20%.
+- Confiabilidad, materiales y reputacion de marca: 20%.
+- Desempeno practico para mi caso de uso: 20%.
+
+Entrega el resultado en este formato:
+1. Resumen ejecutivo con la mejor compra, la opcion economica y la opcion premium si aplica.
+2. Tabla comparativa con precio estimado, ventajas, desventajas, riesgos y puntuacion de 1 a 5.
+3. Analisis del costo total de propiedad, incluyendo consumo electrico aproximado cuando sea posible.
+4. Preguntas clave que debo hacer al vendedor antes de comprar.
+5. Recomendacion final con justificacion clara y advertencias sobre datos que falten.
+
+No inventes precios exactos si no tienes datos confiables. Si necesitas estimar, marca la estimacion como aproximada y explica que debe verificarse con la tienda o fabricante.""",
+        },
+        "personal_nutrition_expert": {
+            "title": "Experto nutriologo personal",
+            "prompt_text": """Actua como un nutriologo personal y asistente de planeacion de comidas.
+
+Objetivo: crear un plan de alimentacion realista de 30 dias que se adapte a mi rutina, presupuesto, preferencias, disponibilidad de cocina y objetivos personales.
+
+Importante: no reemplazas a un profesional de la salud. Si menciono embarazo, diabetes, hipertension, trastornos alimenticios, enfermedades renales, alergias severas, medicacion relevante o sintomas preocupantes, recomiendame consultar a un medico o nutriologo certificado antes de seguir el plan.
+
+No uses el IMC como unico indicador de salud. Considera contexto, energia, adherencia, medidas, historial, actividad fisica y bienestar general.
+
+Primero hazme una sola lista de preguntas para reunir:
+1. Edad, estatura, peso aproximado y objetivo principal.
+2. Nivel de actividad fisica y horarios habituales.
+3. Restricciones medicas, alergias, intolerancias o alimentos que evito.
+4. Presupuesto semanal y pais o ciudad para sugerir alimentos disponibles.
+5. Tiempo para cocinar, equipo de cocina y numero de comidas por dia.
+6. Alimentos favoritos, alimentos que no me gustan y estilo de dieta preferido.
+7. Si quiero bajar grasa, ganar musculo, mantenerme, mejorar energia o planear comidas familiares.
+
+Despues de que responda, genera:
+1. Resumen de objetivos y supuestos.
+2. Guia de porciones practica sin depender de contar calorias exactas.
+3. Menu de 30 dias con desayuno, comida, cena y dos colaciones opcionales.
+4. Lista de compras semanal organizada por categorias.
+5. Opciones de intercambio para cada comida.
+6. Consejos de preparacion para ahorrar tiempo y dinero.
+7. Senales de alerta para pausar el plan y buscar ayuda profesional.
+
+Usa lenguaje claro, realista y amable. Prioriza adherencia, variedad, proteina suficiente, fibra, hidratacion y alimentos accesibles.""",
+        },
+        "influencer_planner": {
+            "title": "Planeador para influencer",
+            "prompt_text": """Actua como un estratega de contenido para influencer y creador digital.
+
+Objetivo: ayudarme a convertir una idea, nicho o marca personal en un plan de contenido accionable para redes sociales, con calendario editorial, guiones, captions, formatos y oportunidades de reutilizacion.
+
+Trabaja en dos pasos.
+
+Paso 1: investiga y sintetiza el contexto.
+- Analiza el nicho, audiencia, propuesta de valor y posibles pilares de contenido.
+- Identifica tendencias, objeciones comunes, formatos utiles y riesgos de comunicacion.
+- No generes todavia el plan completo.
+
+Paso 2: antes de crear el plan, hazme un solo formulario con estas preguntas:
+1. Nicho, tema central o marca personal.
+2. Plataforma principal y plataformas secundarias.
+3. Audiencia objetivo y problema que quiero resolver.
+4. Tono de voz: educativo, aspiracional, divertido, experto, cercano u otro.
+5. Objetivo de negocio: crecer comunidad, vender, conseguir leads, lanzar producto, autoridad o colaboraciones.
+6. Frecuencia de publicacion y tiempo disponible para crear.
+7. Recursos disponibles: video, fotos, diseno, testimonios, productos, presupuesto o equipo.
+8. Temas prohibidos, limites de marca y competidores de referencia.
+
+Despues de que responda, entrega:
+1. Posicionamiento claro en una frase.
+2. 4 a 6 pilares de contenido con ejemplos.
+3. Calendario editorial de 30 dias con formato, hook, idea central, CTA y objetivo de cada pieza.
+4. 10 guiones cortos para Reels, TikTok o Shorts.
+5. 10 captions listos para adaptar.
+6. Ideas para historias, lives y contenido detras de camaras.
+7. Plan de reutilizacion para convertir una pieza larga en varias piezas cortas.
+8. Metricas a revisar semanalmente y ajustes recomendados.
+
+Evita prometer resultados garantizados. Da recomendaciones accionables, medibles y coherentes con la audiencia.""",
+        },
+    },
+    "en": {
+        "appliance_quote_expert": {
+            "title": "Appliance Value Expert",
+            "prompt_text": """Act as an expert appliance quote advisor for buyers in Mexico.
+
+Objective: help me compare purchase options in a practical way, considering price, warranty, total cost of ownership, reliability, and real-world performance for my intended use.
+
+First ask me for these details if I have not provided them:
+1. Appliance type and desired capacity or size.
+2. Maximum budget and city or store where I plan to buy.
+3. Expected use: frequency, number of people, and space constraints.
+4. Brands or models I am already considering.
+5. Personal priorities: price, durability, energy savings, warranty, noise, ease of repair, or smart features.
+
+Once you have the information, evaluate each option with these criteria and weights:
+- Initial price: 20%.
+- Warranty, spare-parts availability, and technical service: 20%.
+- Electricity consumption or estimated operating cost: 20%.
+- Reliability, materials, and brand reputation: 20%.
+- Practical performance for my use case: 20%.
+
+Deliver the result in this format:
+1. Executive summary with the best buy, the budget option, and the premium option if applicable.
+2. Comparison table with estimated price, advantages, disadvantages, risks, and a 1-to-5 score.
+3. Total cost of ownership analysis, including approximate electricity consumption when possible.
+4. Key questions I should ask the seller before buying.
+5. Final recommendation with clear justification and warnings about missing data.
+
+Do not invent exact prices if you do not have reliable data. If you need to estimate, mark the estimate as approximate and explain that it should be verified with the store or manufacturer.""",
+        },
+        "personal_nutrition_expert": {
+            "title": "Personal Meal Planning Expert",
+            "prompt_text": """Act as a personal nutritionist and meal-planning assistant.
+
+Objective: create a realistic 30-day eating plan that fits my routine, budget, preferences, kitchen access, and personal goals.
+
+Important: you are not a replacement for a health professional. If I mention pregnancy, diabetes, hypertension, eating disorders, kidney disease, severe allergies, relevant medication, or concerning symptoms, recommend that I consult a physician or certified nutritionist before following the plan.
+
+Do not use BMI as the only health indicator. Consider context, energy, adherence, measurements, history, physical activity, and overall well-being.
+
+First ask me one single list of questions to gather:
+1. Age, height, approximate weight, and main goal.
+2. Physical activity level and usual schedule.
+3. Medical restrictions, allergies, intolerances, or foods I avoid.
+4. Weekly budget and country or city to suggest available foods.
+5. Time for cooking, kitchen equipment, and number of meals per day.
+6. Favorite foods, foods I dislike, and preferred diet style.
+7. Whether I want to lose fat, gain muscle, maintain, improve energy, or plan family meals.
+
+After I answer, generate:
+1. Summary of goals and assumptions.
+2. Practical portion guide without relying on exact calorie counting.
+3. 30-day menu with breakfast, lunch, dinner, and two optional snacks.
+4. Weekly shopping list organized by category.
+5. Swap options for each meal.
+6. Prep tips to save time and money.
+7. Warning signs to pause the plan and seek professional help.
+
+Use clear, realistic, and kind language. Prioritize adherence, variety, enough protein, fiber, hydration, and accessible foods.""",
+        },
+        "influencer_planner": {
+            "title": "Influencer Content Planner",
+            "prompt_text": """Act as a content strategist for an influencer and digital creator.
+
+Objective: help me turn an idea, niche, or personal brand into an actionable social-media content plan with an editorial calendar, scripts, captions, formats, and repurposing opportunities.
+
+Work in two steps.
+
+Step 1: research and synthesize the context.
+- Analyze the niche, audience, value proposition, and possible content pillars.
+- Identify trends, common objections, useful formats, and communication risks.
+- Do not generate the full plan yet.
+
+Step 2: before creating the plan, ask me one single form with these questions:
+1. Niche, central topic, or personal brand.
+2. Main platform and secondary platforms.
+3. Target audience and problem I want to solve.
+4. Tone of voice: educational, aspirational, funny, expert, approachable, or another style.
+5. Business goal: grow community, sell, get leads, launch a product, build authority, or collaborations.
+6. Publishing frequency and available creation time.
+7. Available resources: video, photos, design, testimonials, products, budget, or team.
+8. Forbidden topics, brand limits, and competitor references.
+
+After I answer, deliver:
+1. Clear one-sentence positioning.
+2. 4 to 6 content pillars with examples.
+3. 30-day editorial calendar with format, hook, core idea, CTA, and goal for each piece.
+4. 10 short scripts for Reels, TikTok, or Shorts.
+5. 10 captions ready to adapt.
+6. Ideas for stories, lives, and behind-the-scenes content.
+7. Repurposing plan to turn one long-form piece into several short pieces.
+8. Metrics to review weekly and recommended adjustments.
+
+Avoid promising guaranteed results. Give actionable, measurable recommendations that fit the audience.""",
+        },
+    },
+}
+
+
+def get_creator_prompt_seeds(language: str) -> list[CreatorPromptSeed]:
+    if language not in _LOCALIZED_SEEDS:
+        raise ValueError("Unsupported creator prompt language")
+
+    localized = _LOCALIZED_SEEDS[language]
+    seeds: list[CreatorPromptSeed] = []
+    for key, metadata in _SEED_METADATA.items():
+        prompt = localized[key]
+        seeds.append(
+            {
+                "key": key,
+                "title": prompt["title"],
+                "prompt_text": prompt["prompt_text"],
+                "category": metadata["category"],
+                "model_name": metadata["model_name"],
+                "rate": metadata["rate"],
+            }
+        )
+    return seeds

--- a/webapi/models/prompts.py
+++ b/webapi/models/prompts.py
@@ -16,6 +16,7 @@ PROMPT_TEXT_SQL_TYPE = (
 class Prompts(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     user_id: int = Field(foreign_key="user.id", nullable=False)
+    title: str = Field(max_length=120, nullable=False)
     model_name: str = Field(max_length=30, nullable=False)
     prompt_text: str = Field(sa_column=Column(PROMPT_TEXT_SQL_TYPE, nullable=False))
     category: str = Field(max_length=30, nullable=False)

--- a/webapi/models/user.py
+++ b/webapi/models/user.py
@@ -11,6 +11,12 @@ class User(SQLModel, table=True):
     last_name: str = Field(max_length=100, index=True, nullable=False)
     email: EmailStr = Field(max_length=100, nullable=False)
     hashed_password: str = Field(max_length=255)  # Longer for bcrypt hashes
+    preferred_language: str = Field(
+        default="es",
+        max_length=2,
+        nullable=False,
+        sa_column_kwargs={"server_default": "es"},
+    )
     role: str = Field(
         default="user",
         max_length=20,

--- a/webapi/schemas/prompt_schema.py
+++ b/webapi/schemas/prompt_schema.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field, field_validator
 
 class PromptCreate(BaseModel):
     user_id: Optional[int] = None
+    title: str = Field(min_length=1, max_length=120)
     model_name: str = Field(min_length=1, max_length=MODEL_NAME_MAX_CHARS)
     prompt_text: str = Field(min_length=1, max_length=PROMPT_TEXT_MAX_CHARS)
     category: str
@@ -29,6 +30,8 @@ class PromptCreate(BaseModel):
 
 class PromptRead(BaseModel):
     id: int
+    user_id: int
+    title: str
     model_name: str
     prompt_text: str
     category: str

--- a/webapi/schemas/user_schema.py
+++ b/webapi/schemas/user_schema.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Literal
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 from .prompt_schema import PromptRead
 
@@ -13,6 +13,7 @@ class UserCreate(BaseModel):
                 "last_name": "testing",
                 "email": "user@example.com",
                 "password": "usertest",
+                "preferred_language": "es",
             }
         },
     )
@@ -22,6 +23,7 @@ class UserCreate(BaseModel):
     last_name: str = Field(max_length=100)
     email: EmailStr = Field(max_length=100)
     password: str = Field(max_length=255)
+    preferred_language: Literal["es", "en"] = "es"
 
 
 class UserRead(BaseModel):
@@ -32,6 +34,7 @@ class UserRead(BaseModel):
     name: str
     last_name: str
     email: str
+    preferred_language: str
     role: str
 
 class UserReadWithPrompts(BaseModel):
@@ -42,5 +45,6 @@ class UserReadWithPrompts(BaseModel):
     name: str
     last_name: str
     email: str
+    preferred_language: str
     role: str
     prompts: List[PromptRead] = []

--- a/webapi/tests/conftest.py
+++ b/webapi/tests/conftest.py
@@ -82,6 +82,7 @@ def user_payload():
         "last_name": "Tester",
         "email": "pytest_user@example.com",
         "password": "pytest_password",
+        "preferred_language": "es",
     }
 
 
@@ -110,6 +111,7 @@ def auth_header(created_user):
 def created_prompt(db_session, created_user):
     prompt = Prompts(
         user_id=created_user.id,
+        title="Existing prompt",
         model_name=VALID_MODEL_NAME,
         prompt_text="existing prompt",
         category="qa",

--- a/webapi/tests/functional/test_auth_routes.py
+++ b/webapi/tests/functional/test_auth_routes.py
@@ -4,6 +4,7 @@ from passlib.hash import sha256_crypt
 from sqlmodel import select
 
 from models.user import User
+from models.prompts import Prompts
 import api.endpoints.v1.auths as auths_module
 from auth.auth_service import validar_jwt_raw
 
@@ -12,14 +13,30 @@ def test_signup_success(client, user_payload, db_session):
     response = client.post("/api/v1/auth/signup", json=user_payload)
 
     assert response.status_code == 200
-    assert response.json() == {"message": "User created successfully"}
+    body = response.json()
+    assert body["message"] == "User created successfully"
+    assert body["token_type"] == "bearer"
+    assert isinstance(body["access_token"], str)
+    assert body["user"]["username"] == user_payload["username"]
+    assert body["user"]["preferred_language"] == "es"
 
     created = db_session.exec(select(User).where(User.username == user_payload["username"])).first()
     assert created is not None
     assert isinstance(created.id, int)
     assert created.role == "user"
+    assert created.preferred_language == "es"
     assert created.hashed_password != user_payload["password"]
     assert sha256_crypt.verify(user_payload["password"], created.hashed_password)
+
+    seeded_prompts = db_session.exec(select(Prompts).where(Prompts.user_id == created.id)).all()
+    assert len(seeded_prompts) == 3
+    assert {prompt.title for prompt in seeded_prompts} == {
+        "Experto cotizador de electrodomesticos",
+        "Experto nutriologo personal",
+        "Planeador para influencer",
+    }
+    assert {prompt.model_name for prompt in seeded_prompts} == {"gpt"}
+    assert {prompt.rate for prompt in seeded_prompts} == {5}
 
 
 def test_signup_rejects_client_supplied_id(client, user_payload, db_session):
@@ -82,11 +99,49 @@ def test_signup_duplicate_username_returns_400(client, db_session):
             "last_name": "user",
             "email": "new_dup_user@example.com",
             "password": "password",
+            "preferred_language": "es",
         },
     )
 
     assert response.status_code == 400
     assert response.json()["detail"] == "username already taken"
+    prompts = db_session.exec(select(Prompts)).all()
+    assert prompts == []
+
+
+def test_signup_preferred_language_controls_seed_prompt_language(client, db_session):
+    response = client.post(
+        "/api/v1/auth/signup",
+        json={
+            "username": "english_user",
+            "name": "English",
+            "last_name": "User",
+            "email": "english_user@example.com",
+            "password": "password",
+            "preferred_language": "en",
+        },
+    )
+
+    assert response.status_code == 200
+    created = db_session.exec(select(User).where(User.username == "english_user")).first()
+    seeded_prompts = db_session.exec(select(Prompts).where(Prompts.user_id == created.id)).all()
+    assert response.json()["user"]["preferred_language"] == "en"
+    assert {prompt.title for prompt in seeded_prompts} == {
+        "Appliance Value Expert",
+        "Personal Meal Planning Expert",
+        "Influencer Content Planner",
+    }
+
+
+def test_signup_rejects_unsupported_preferred_language(client, user_payload, db_session):
+    response = client.post(
+        "/api/v1/auth/signup",
+        json={**user_payload, "preferred_language": "fr"},
+    )
+
+    assert response.status_code == 422
+    created = db_session.exec(select(User).where(User.username == user_payload["username"])).first()
+    assert created is None
 
 
 def test_signup_rejects_client_supplied_role(client, user_payload, db_session):

--- a/webapi/tests/functional/test_prompts_routes.py
+++ b/webapi/tests/functional/test_prompts_routes.py
@@ -39,6 +39,7 @@ def create_prompt(
 ) -> Prompts:
     prompt = Prompts(
         user_id=user_id,
+        title=f"{category} prompt title",
         model_name=model_name,
         prompt_text=f"{category} prompt {rate}",
         category=category,
@@ -53,6 +54,7 @@ def create_prompt(
 def test_create_prompt_success(client, auth_header, created_user):
     payload = {
         "user_id": created_user.id,
+        "title": "Answer generator",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "Generate answer",
         "category": "qa",
@@ -63,6 +65,7 @@ def test_create_prompt_success(client, auth_header, created_user):
 
     assert response.status_code == 200
     assert response.json()["user_id"] == created_user.id
+    assert response.json()["title"] == "Answer generator"
     assert response.json()["model_name"] == VALID_MODEL_NAME
 
 
@@ -70,6 +73,7 @@ def test_create_prompt_accepts_prompt_text_longer_than_150_chars(client, auth_he
     prompt_text = "x" * 151
     payload = {
         "user_id": created_user.id,
+        "title": "Long prompt",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": prompt_text,
         "category": "qa",
@@ -85,6 +89,7 @@ def test_create_prompt_accepts_prompt_text_longer_than_150_chars(client, auth_he
 def test_create_prompt_rejects_prompt_text_above_max_chars(client, auth_header, created_user):
     payload = {
         "user_id": created_user.id,
+        "title": "Too long prompt",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "x" * (PROMPT_TEXT_MAX_CHARS + 1),
         "category": "qa",
@@ -99,6 +104,7 @@ def test_create_prompt_rejects_prompt_text_above_max_chars(client, auth_header, 
 def test_create_prompt_rejects_unknown_model_name(client, auth_header, created_user, db_session):
     payload = {
         "user_id": created_user.id,
+        "title": "Unknown model",
         "model_name": "unknown-model",
         "prompt_text": "Unknown model should not persist",
         "category": "qa",
@@ -115,6 +121,7 @@ def test_create_prompt_rejects_unknown_model_name(client, auth_header, created_u
 def test_create_prompt_unauthorized_returns_401(client, created_user):
     payload = {
         "user_id": created_user.id,
+        "title": "Unauthorized prompt",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "Generate answer",
         "category": "qa",
@@ -134,6 +141,7 @@ def test_create_prompt_unauthorized_returns_401(client, created_user):
 def test_create_prompt_user_not_found_returns_404(client, auth_header):
     payload = {
         "user_id": 9999,
+        "title": "Missing user prompt",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "Generate answer",
         "category": "qa",
@@ -150,6 +158,7 @@ def test_regular_user_cannot_create_prompt_for_another_user(client, auth_header,
     other_user = create_user(db_session, "create_other_user")
     payload = {
         "user_id": other_user.id,
+        "title": "Forbidden prompt",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "not allowed",
         "category": "qa",
@@ -174,6 +183,7 @@ def test_create_prompt_send_email_true_calls_email(client, auth_header, created_
 
     payload = {
         "user_id": created_user.id,
+        "title": "Notification prompt",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "Notify me",
         "category": "qa",
@@ -195,6 +205,7 @@ def test_create_prompt_send_email_exception_still_success(client, auth_header, c
 
     payload = {
         "user_id": created_user.id,
+        "title": "Email resilient prompt",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "Ignore email failure",
         "category": "ops",
@@ -285,6 +296,7 @@ def test_get_prompt_missing_returns_404(client, auth_header):
 def test_update_prompt_success(client, auth_header, created_prompt, created_user):
     payload = {
         "user_id": created_user.id,
+        "title": "Updated title",
         "model_name": ALTERNATE_MODEL_NAME,
         "prompt_text": "Updated prompt",
         "category": "dev",
@@ -295,12 +307,14 @@ def test_update_prompt_success(client, auth_header, created_prompt, created_user
 
     assert response.status_code == 200
     assert response.json()["model_name"] == ALTERNATE_MODEL_NAME
+    assert response.json()["title"] == "Updated title"
     assert response.json()["prompt_text"] == "Updated prompt"
 
 
 def test_update_prompt_rejects_unknown_model_name(client, auth_header, created_prompt, created_user, db_session):
     payload = {
         "user_id": created_user.id,
+        "title": "Unknown update",
         "model_name": "unknown-model",
         "prompt_text": "Unknown model should not update",
         "category": "dev",
@@ -318,6 +332,7 @@ def test_update_prompt_rejects_unknown_model_name(client, auth_header, created_p
 def test_update_prompt_missing_returns_404(client, auth_header, created_user):
     payload = {
         "user_id": created_user.id,
+        "title": "Missing update",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "Updated prompt",
         "category": "qa",
@@ -333,6 +348,7 @@ def test_update_prompt_missing_returns_404(client, auth_header, created_user):
 def test_update_prompt_user_not_found_returns_404(client, auth_header, created_prompt):
     payload = {
         "user_id": 9999,
+        "title": "Missing update user",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "Updated prompt",
         "category": "qa",
@@ -349,6 +365,7 @@ def test_god_can_update_another_users_prompt(client, db_session, created_prompt)
     god = create_user(db_session, "update_god", role="god")
     payload = {
         "user_id": created_prompt.user_id,
+        "title": "God update title",
         "model_name": ALTERNATE_MODEL_NAME,
         "prompt_text": "god update",
         "category": "research",
@@ -362,6 +379,7 @@ def test_god_can_update_another_users_prompt(client, db_session, created_prompt)
     )
 
     assert response.status_code == 200
+    assert response.json()["title"] == "God update title"
     assert response.json()["model_name"] == ALTERNATE_MODEL_NAME
     assert response.json()["prompt_text"] == "god update"
 
@@ -369,6 +387,7 @@ def test_god_can_update_another_users_prompt(client, db_session, created_prompt)
 def test_prompt_rating_validation_rejects_out_of_range_values(client, auth_header, created_user):
     payload = {
         "user_id": created_user.id,
+        "title": "Bad rating",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "bad rating",
         "category": "qa",
@@ -383,6 +402,7 @@ def test_prompt_rating_validation_rejects_out_of_range_values(client, auth_heade
 def test_prompt_rating_validation_rejects_non_integer_values(client, auth_header, created_user):
     payload = {
         "user_id": created_user.id,
+        "title": "Decimal rating",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "bad rating",
         "category": "qa",
@@ -440,6 +460,7 @@ def test_regular_user_cannot_read_another_users_prompt(client, auth_header, db_s
     db_session.refresh(other_user)
     prompt = Prompts(
         user_id=other_user.id,
+        title="Private prompt",
         model_name=VALID_MODEL_NAME,
         prompt_text="private prompt",
         category="qa",
@@ -477,6 +498,7 @@ def test_admin_can_read_all_prompts_but_cannot_update(client, db_session, create
         f"/api/v1/prompts/{created_prompt.id}",
         json={
             "user_id": created_prompt.user_id,
+            "title": "Admin update title",
             "model_name": ALTERNATE_MODEL_NAME,
             "prompt_text": "admin update",
             "category": "dev",

--- a/webapi/tests/nonfunctional/test_ci.py
+++ b/webapi/tests/nonfunctional/test_ci.py
@@ -24,15 +24,15 @@ def test_register_user():
         "name": "user to test",
         "last_name": "my webapp",
         "email": "pytestmyapp@testing.com",
-        "password": TEST_PSW
+        "password": TEST_PSW,
+        "preferred_language": "es",
     })
     assert response.status_code in (200, 400)
     if response.status_code == 400:
         assert response.json().get("detail") == "username already taken"
     else:
-        assert response.json() == {
-            "message": "User created successfully"
-        }
+        assert response.json()["message"] == "User created successfully"
+        assert response.json()["token_type"] == "bearer"
 
 def get_token():
     response = client.post("/api/v1/auth/login", json={
@@ -49,6 +49,7 @@ def test_register_prompt():
     headers = {"Authorization": f"Bearer {token}", "send_email": "false"}
     response = client.post("/api/v1/prompts", json={
         "user_id": 1,
+        "title": "CI test prompt",
         "model_name": VALID_MODEL_NAME,
         "prompt_text": "Generate a test response",
         "category": "qa",


### PR DESCRIPTION
Add required prompt titles across backend and frontend prompt flows.

Return authenticated signup sessions with preferred language support.

Seed new user accounts with localized creator prompts.

Update landing page messaging and fix long prompt detail dialog overflow.